### PR TITLE
Add script to generate .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ This repository contains example scripts that interact with the [Filevine](https
    ```bash
    pip install requests python-dotenv
    ```
-2. Create a `.env` file in this directory with the following values:
+2. Generate a `.env` file containing your credentials:
+   ```bash
+   python create_env.py
+   ```
+   The script prompts for your Personal Access Token, Client ID and Client Secret
+   and writes them to `.env` in this folder. Alternatively you can create the file
+   manually with the following values:
    ```
    FILEVINE_PAT=your_personal_access_token
    FILEVINE_CLIENT_ID=your_client_id

--- a/create_env.py
+++ b/create_env.py
@@ -1,0 +1,28 @@
+import getpass
+from pathlib import Path
+
+
+def main() -> None:
+    """Interactive helper to create a .env file with Filevine credentials."""
+    env_path = Path(__file__).resolve().parent / ".env"
+    if env_path.exists():
+        resp = input(f"A .env file already exists at {env_path}. Overwrite it? [y/N] ").strip().lower()
+        if resp != "y":
+            print("Aborted. Existing .env left unchanged.")
+            return
+
+    pat = getpass.getpass("Enter your Filevine Personal Access Token: ")
+    client_id = input("Enter your Filevine Client ID: ")
+    client_secret = getpass.getpass("Enter your Filevine Client Secret: ")
+
+    content = (
+        f"FILEVINE_PAT={pat}\n"
+        f"FILEVINE_CLIENT_ID={client_id}\n"
+        f"FILEVINE_CLIENT_SECRET={client_secret}\n"
+    )
+    env_path.write_text(content)
+    print(f"✅ Credentials written to {env_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script `create_env.py` that prompts for Filevine credentials and writes `.env`
- document `create_env.py` in the setup instructions

## Testing
- `python -m py_compile ProjectDocsDownload.py TestConnection.py create_env.py`

------
https://chatgpt.com/codex/tasks/task_b_6848915e8900832f8a4ecb4b691e78cc