### PR TITLE
Add GUI prompts for project ID and destination

### DIFF
--- a/ProjectDocsDownload.py
+++ b/ProjectDocsDownload.py
@@ -35,6 +35,9 @@ import sys
 import time
 from typing import Dict, List, Optional
 
+import tkinter as tk
+from tkinter import filedialog, simpledialog
+
 import requests
 from dotenv import load_dotenv
 
@@ -203,12 +206,36 @@ def download_document(
 def main() -> None:
     load_dotenv()
 
-    parser = argparse.ArgumentParser(description="Download Filevine project documents.")
-    parser.add_argument("--project", type=int, required=True, help="Filevine projectId")
-    parser.add_argument("--dest", default="./downloads", help="Destination directory")
+    parser = argparse.ArgumentParser(
+        description="Download Filevine project documents."
+    )
+    parser.add_argument("--project", type=int, help="Filevine projectId")
+    parser.add_argument("--dest", help="Destination directory")
     parser.add_argument("--workers", type=int, default=4, help="Concurrent download workers")
     parser.add_argument("--dry-run", action="store_true", help="List docs without downloading")
     args = parser.parse_args()
+
+    if args.project is None or args.dest is None:
+        root = tk.Tk()
+        root.withdraw()
+        if args.project is None:
+            pid = simpledialog.askstring(
+                "Project ID", "Enter the Filevine project ID:", parent=root
+            )
+            if pid is None:
+                sys.exit("Project ID is required")
+            try:
+                args.project = int(pid)
+            except ValueError:
+                sys.exit("Project ID must be an integer")
+        if args.dest is None:
+            path = filedialog.askdirectory(
+                title="Select download destination", parent=root
+            )
+            if not path:
+                sys.exit("Destination directory is required")
+            args.dest = path
+        root.destroy()
 
     pat = os.getenv("FILEVINE_PAT")
     cid = os.getenv("FILEVINE_CLIENT_ID")

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ These environment variables are required for authenticating with the Filevine AP
 ```bash
 python ProjectDocsDownload.py --project <projectId> --dest ./downloads --workers 4
 ```
-- `--project`  – ID of the Filevine project to download from (required).
-- `--dest`     – Local directory where documents will be written. The script creates sub‑folders to mirror Filevine's structure.
+If `--project` or `--dest` are omitted, a small window will prompt for the
+project ID and let you choose the destination directory.
+- `--project`  – ID of the Filevine project to download from.
+- `--dest`     – Local directory where documents will be written.
 - `--workers`  – Number of concurrent download workers (default: 4).
 - `--dry-run`  – Show which files would be downloaded without saving anything.
 


### PR DESCRIPTION
## Summary
- make project ID and destination CLI flags optional
- show Tkinter dialogs when either is missing
- document the new interactive behavior

## Testing
- `python -m py_compile ProjectDocsDownload.py`

------
https://chatgpt.com/codex/tasks/task_b_684897b6769c832f9f05f36c5e896c9f