### PR TITLE
Remove Tkinter prompts

### DIFF
--- a/ProjectDocsDownload.py
+++ b/ProjectDocsDownload.py
@@ -35,8 +35,6 @@ import sys
 import time
 from typing import Dict, List, Optional
 
-import tkinter as tk
-from tkinter import filedialog, simpledialog
 
 import requests
 from dotenv import load_dotenv
@@ -215,27 +213,20 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true", help="List docs without downloading")
     args = parser.parse_args()
 
-    if args.project is None or args.dest is None:
-        root = tk.Tk()
-        root.withdraw()
-        if args.project is None:
-            pid = simpledialog.askstring(
-                "Project ID", "Enter the Filevine project ID:", parent=root
-            )
-            if pid is None:
-                sys.exit("Project ID is required")
-            try:
-                args.project = int(pid)
-            except ValueError:
-                sys.exit("Project ID must be an integer")
-        if args.dest is None:
-            path = filedialog.askdirectory(
-                title="Select download destination", parent=root
-            )
-            if not path:
-                sys.exit("Destination directory is required")
-            args.dest = path
-        root.destroy()
+    if args.project is None:
+        pid = input("Enter the Filevine project ID: ").strip()
+        if not pid:
+            sys.exit("Project ID is required")
+        try:
+            args.project = int(pid)
+        except ValueError:
+            sys.exit("Project ID must be an integer")
+
+    if args.dest is None:
+        path = input("Enter the download destination directory: ").strip()
+        if not path:
+            sys.exit("Destination directory is required")
+        args.dest = path
 
     pat = os.getenv("FILEVINE_PAT")
     cid = os.getenv("FILEVINE_CLIENT_ID")

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ These environment variables are required for authenticating with the Filevine AP
 ```bash
 python ProjectDocsDownload.py
 ```
-Running the script without flags opens small prompts asking for the project ID
-and the folder where you want the files saved. You can still pass the values on
-the command line if you prefer:
+Running the script without flags triggers interactive prompts in your terminal
+to ask for the project ID and destination folder. You can still supply the
+values on the command line if you prefer:
 ```bash
 python ProjectDocsDownload.py --project <projectId> --dest ./downloads --workers 4
 ```
 - `--project`  – ID of the Filevine project to download from. Optional if you
-  supply it via the prompt.
+  supply it via the interactive prompt.
 - `--dest`     – Local directory where documents will be written. Optional if
-  chosen via the prompt.
+  chosen via the interactive prompt.
 - `--workers`  – Number of concurrent download workers (default: 4).
 - `--dry-run`  – Show which files would be downloaded without saving anything.
 


### PR DESCRIPTION
## Summary
- replace GUI prompts with text-based `input()` calls
- update README to mention new command line prompts

## Testing
- `python -m py_compile ProjectDocsDownload.py create_env.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6848a209c188832fa0ab08c998453199