### PR TITLE
Add export logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ python ProjectDocsDownload.py --project <projectId> --dest ./downloads --workers
   chosen via the interactive prompt.
 - `--workers`  – Number of concurrent download workers (default: 4).
 - `--dry-run`  – Show which files would be downloaded without saving anything.
+- `--log`      – Path to a log file capturing the export process (default: `download_log.txt`).
 
 
 ## License


### PR DESCRIPTION
## Summary
- add logging setup to `ProjectDocsDownload.py`
- log messages to console and a `.txt` file
- document the new `--log` command line argument

## Testing
- `python -m py_compile ProjectDocsDownload.py create_env.py`
- `python ProjectDocsDownload.py --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_b_6848a5693294832fb86db00a0f920c16