### PR TITLE
Add GUI folder selection

### DIFF
--- a/ProjectDocsDownload.py
+++ b/ProjectDocsDownload.py
@@ -36,6 +36,11 @@ import sys
 import time
 from typing import Dict, List, Optional
 
+try:
+    from tkinter import Tk, filedialog  # type: ignore
+except Exception:
+    filedialog = None  # fall back to CLI prompt if tkinter is unavailable
+
 
 import requests
 from dotenv import load_dotenv
@@ -246,7 +251,13 @@ def main() -> None:
             sys.exit("Project ID must be an integer")
 
     if args.dest is None:
-        path = input("Enter the download destination directory: ").strip()
+        if filedialog is not None:
+            root = Tk()
+            root.withdraw()
+            path = filedialog.askdirectory(title="Select download folder")
+            root.destroy()
+        else:
+            path = input("Enter the download destination directory: ").strip()
         if not path:
             sys.exit("Destination directory is required")
         args.dest = path

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ These environment variables are required for authenticating with the Filevine AP
 ```bash
 python ProjectDocsDownload.py
 ```
-Running the script without flags triggers interactive prompts in your terminal
-to ask for the project ID and destination folder. You can still supply the
-values on the command line if you prefer:
+Running the script without flags triggers interactive prompts. The project ID is
+requested on the command line and, if Tkinter is available, a folder selection
+dialog pops up to choose the destination directory (otherwise you can type the
+path). You can still supply the values on the command line if you prefer:
 ```bash
 python ProjectDocsDownload.py --project <projectId> --dest ./downloads --workers 4
 ```


### PR DESCRIPTION
## Summary
- add Tkinter-based folder selection when `--dest` is not provided
- update documentation to mention the new folder dialog

## Testing
- `python -m py_compile ProjectDocsDownload.py create_env.py`

------
https://chatgpt.com/codex/tasks/task_b_6851f0fd3ff4832f943ab2a844bb2894